### PR TITLE
feat(video): add native lazy loading and accessibility improvements to iframe

### DIFF
--- a/src/routes/over/+page.svelte
+++ b/src/routes/over/+page.svelte
@@ -22,8 +22,9 @@
 		<p>{data.abouts[0].description4}</p>
 	</section>
 
-	<section class="video-wrapper">
+	<section class="video-wrapper" aria-label="Event highlight video">
 		<iframe
+  			loading="lazy"
   			width="100%"
   			height="480"
   			src="https://www.youtube.com/embed/qEykT9dSNfg"
@@ -32,7 +33,6 @@
   			allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
   			allowfullscreen>
 		</iframe>
-
 	</section>
 </main>
 
@@ -201,7 +201,7 @@
     		padding-bottom: 56.25%; 
     		height: 0;
     		overflow: hidden;
-			max-width: 42vw;
+			max-width: 44vw;
 			display: flex;
 			margin: 0 auto;
   		}

--- a/src/routes/over/+page.svelte
+++ b/src/routes/over/+page.svelte
@@ -21,6 +21,19 @@
 		<p>{data.abouts[0].description3}</p>
 		<p>{data.abouts[0].description4}</p>
 	</section>
+
+	<section class="video-wrapper">
+		<iframe
+  			width="100%"
+  			height="480"
+  			src="https://www.youtube.com/embed/qEykT9dSNfg"
+  			title="Openingsfeest Bieb in Bloei"
+  			frameborder="0"
+  			allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+  			allowfullscreen>
+		</iframe>
+
+	</section>
 </main>
 
 <style>
@@ -64,6 +77,10 @@
 		font-style: oblique;
 		font-weight: bolder;
 	}
+
+	.video-wrapper iframe {
+		border-radius: var(--border-card);
+  	}
 
 	/* MEDIA QUERY STYLING */
 	/* DESKTOP */
@@ -110,6 +127,20 @@
 		p {
 			margin-top: 1.5em;
 		}
+
+		.video-wrapper {
+    		position: relative;
+    		padding-bottom: 56.25%; 
+    		height: 0;
+    		overflow: hidden;
+			width: 47vw;
+			display: flex;
+			margin: 0 auto;
+  		}
+
+  		.video-wrapper iframe {
+			border-radius: var(--border-card);
+  		}
 	}
 
 	/* TABLET */
@@ -134,6 +165,10 @@
 		h2 {
 			font-size: 3em;
 		}
+
+		.video-wrapper iframe {
+			border-radius: var(--border-card);
+  		}
 	}
 
 	/* BIG DESKTOP SCREEN */
@@ -160,5 +195,19 @@
 			line-height: 1.5em;
 			margin-top: 1.5em;
 		}
+
+		.video-wrapper {
+    		position: relative;
+    		padding-bottom: 56.25%; 
+    		height: 0;
+    		overflow: hidden;
+			max-width: 42vw;
+			display: flex;
+			margin: 0 auto;
+  		}
+
+  		.video-wrapper iframe {
+			border-radius: var(--border-card);
+  		}
 	}
 </style>


### PR DESCRIPTION
# Description
This PR improves the embedded YouTube video by:

- Adding native lazy loading with `loading="lazy"` on the `<iframe>`
- Enhancing accessibility with:
  - A descriptive `aria-label` on the surrounding `<section>`
  - A meaningful `title` attribute on the `<iframe>

![Screenshot 2025-05-28 113715](https://github.com/user-attachments/assets/254071c0-0c37-4220-8f22-aeb9cd528d18)



Fixes #470 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)



# How Has This Been Tested?

The embedded video has been tested on responsiveness, performance and accessibility by using Lighthouse

- [x] Accessibility test
- [x] Performance test
- [x] Responsive Design test

![Screenshot 2025-05-28 114034](https://github.com/user-attachments/assets/f572c9ce-4633-4bfa-ac05-d3be9d98345d)

![Screenshot 2025-05-28 114111](https://github.com/user-attachments/assets/b12d5170-fb91-46ee-9a86-c0ba0868dc3b)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] The code is accessible
- [x] The code is performant
- [x] The code is responsive
- [x] I have written meaningful commit messages
- [x] I have performed a self-review of my code




