### PR TITLE
refractor title split logic intro-headers

### DIFF
--- a/src/lib/atoms/intro-headers.svelte
+++ b/src/lib/atoms/intro-headers.svelte
@@ -1,13 +1,18 @@
 <script>
 	let { heroInfo } = $props();
+	const words = heroInfo.title.split(' ');
+	const half = Math.ceil(words.length / 2);
+	const firstHalf = words.slice(0, half).join(' ');
+	const secondHalf = words.slice(half).join(' ');
 </script>
 
 <section>
 	<h2>
-		<span class="outline">{heroInfo.title.split(' ')[0]}</span><br />
-		{heroInfo.title.split(' ')[1]}
+		<span class="outline">{firstHalf}</span>
+		{#if secondHalf}
+		<br />{secondHalf}
+		{/if}
 	</h2>
-	
 	<p>{heroInfo.description}</p>
 </section>
 

--- a/src/lib/atoms/intro-headers.svelte
+++ b/src/lib/atoms/intro-headers.svelte
@@ -30,7 +30,7 @@
 
 	.outline {
 		color: transparent;
-		-webkit-text-stroke: 1.5px var(--main-color-green);
+		-webkit-text-stroke: 1.8px var(--main-color-green);
 	}
 
 	/* Tablet */

--- a/src/routes/stekjes/+page.svelte
+++ b/src/routes/stekjes/+page.svelte
@@ -27,7 +27,7 @@
 
 <HeroHeaders heroInfo={data.heroHeaders[0]} />
 
-<!-- <IntroHeaders heroInfo={data.heroHeaders[8]} /> -->
+<IntroHeaders heroInfo={data.heroHeaders[8]} />
 
 <Stekjesfilter on:showAll={showAll} on:showCurrent={showCurrent} active={activeFilter} {data} />
 

--- a/src/routes/workshops/+page.svelte
+++ b/src/routes/workshops/+page.svelte
@@ -26,15 +26,9 @@
 
 <HeroHeaders heroInfo={data.heroHeaders[3]} />
 
-<section class="intro">
-	<IntroHeaders heroInfo={data.heroHeaders[3]} />
-</section>
+<IntroHeaders heroInfo={data.heroHeaders[3]} />
 
-<section class="workshops">
-	<h2>
-		<span class="outline">{data.sectionInfos[1].title.split(' ')[0]}</span><br />
-		{data.sectionInfos[1].title.split(' ')[1]}
-	</h2>
+<main>
 	{#if data.agendas && data.agendas.length > 0}
 	<ul>
 		{#each data.agendas as agenda}
@@ -49,6 +43,7 @@
 			<time>{agenda.date}</time>
 			<time>{agenda.time}</time>
 			<address>{agenda.address}</address>
+			<p>{agenda.price}</p>
 			<Button href="/contact" buttonText="Aanmelden" buttonClass={agenda.buttonClass} svgFill="svg-beige" />
 		</li>
 		{/each}
@@ -56,27 +51,13 @@
 	{:else}
 	<p>Er zijn momenteel geen workshops beschikbaar.</p>
 	{/if}
-</section>
+</main>
 
 <style>
-	.workshops {
-		margin: 1em;
-	}
-
-	h2 {
-		margin-bottom: 0.25em;
-		text-transform: uppercase;
-		color: var(--main-color-brown);
-	}
-
-	.outline {
-		color: transparent;
-		-webkit-text-stroke: 1.5px var(--main-color-brown);
-	}
-
 	ul {
 		display: flex;
 		flex-direction: column;
+		margin: 1em;
 		gap: 1rem;
 		list-style: none;
 		color: var(--main-color-brown);
@@ -119,6 +100,10 @@
 	time,
 	address {
 		font-weight: bold;
+	}
+
+	address {
+		margin-bottom: 1em;
 	}
 
 	/* workshop cards varianten */

--- a/src/routes/workshops/+page.svelte
+++ b/src/routes/workshops/+page.svelte
@@ -65,7 +65,7 @@
 
 	li {
 		position: relative;
-		height: 30em;
+		height: 33em;
 		background-color: var(--main-color-beige);
 		border-radius: 1em;
 		padding: 1em;


### PR DESCRIPTION
# Description

**title splitting**
The logic for splitting the title has been improved. Previously, it only worked correctly for titles with exactly two words, if more than 2 words de title wouldn't be full rendered. It now dynamically splits the title into two halves, regardless of the number of words.

**semantics**
I removed an unnecessary `<section>` element to simplify the HTML structure and improve semantics.

Fixes #496 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

- [x] Accessibility test
- [x] Performance test
- [x] Responsive Design test

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] The code is accessible
- [x] The code is performant
- [x] The code is responsive
- [x] I have written meaningful commit messages
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (README and/or Wiki)

# How to review:
- Review my code
- Check the `IntroHeaders` component with different title lengths 

# Before / After:
![image](https://github.com/user-attachments/assets/fc2dd2de-f19c-490c-b73d-6397df3e3544)

![image](https://github.com/user-attachments/assets/8742d358-977e-4157-b0f9-e7ab097df17a)